### PR TITLE
feat(#48): implement skeleton component

### DIFF
--- a/src/main/kotlin/org/patternfly/A11y.kt
+++ b/src/main/kotlin/org/patternfly/A11y.kt
@@ -1,0 +1,10 @@
+package org.patternfly
+
+/**
+ * Creates a CSS class for screen-reader
+ * The content is invisible and only available to a screen reader, use inspector to investigate
+ *
+ * @see <a href="https://www.patternfly.org/v4/utilities/accessibility/#screen-reader-only">
+ *     https://www.patternfly.org/v4/utilities/accessibility/#screen-reader-only</a>
+ */
+public fun screenReader(): String = "screen-reader".util()

--- a/src/main/kotlin/org/patternfly/Bem.kt
+++ b/src/main/kotlin/org/patternfly/Bem.kt
@@ -29,27 +29,6 @@ public fun String.layout(vararg elements: String): String = combine("pf-l", this
 public fun String.modifier(): String = "pf-m-$this"
 
 /**
- * Creates a PatternFly modifier CSS class starting with `pf-m-text-`.
- *
- * @receiver the modifier name
- */
-public fun String.text(): String = "pf-m-text-$this"
-
-/**
- * Creates a PatternFly modifier CSS class starting with `pf-m-height-`.
- *
- * @receiver the modifier name
- */
-public fun String.height(): String = "pf-m-height-$this"
-
-/**
- * Creates a PatternFly modifier CSS class starting with `pf-m-width-`.
- *
- * @receiver the modifier name
- */
-public fun String.width(): String = "pf-m-width-$this"
-
-/**
  * Creates a PatternFly utility CSS class starting with `pf-u-`.
  *
  * @receiver the utility name

--- a/src/main/kotlin/org/patternfly/Bem.kt
+++ b/src/main/kotlin/org/patternfly/Bem.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package org.patternfly
 
 /**
@@ -25,6 +27,27 @@ public fun String.layout(vararg elements: String): String = combine("pf-l", this
  * @receiver the modifier name
  */
 public fun String.modifier(): String = "pf-m-$this"
+
+/**
+ * Creates a PatternFly modifier CSS class starting with `pf-m-text-`.
+ *
+ * @receiver the modifier name
+ */
+public fun String.text(): String = "pf-m-text-$this"
+
+/**
+ * Creates a PatternFly modifier CSS class starting with `pf-m-height-`.
+ *
+ * @receiver the modifier name
+ */
+public fun String.height(): String = "pf-m-height-$this"
+
+/**
+ * Creates a PatternFly modifier CSS class starting with `pf-m-width-`.
+ *
+ * @receiver the modifier name
+ */
+public fun String.width(): String = "pf-m-width-$this"
 
 /**
  * Creates a PatternFly utility CSS class starting with `pf-u-`.

--- a/src/main/kotlin/org/patternfly/Skeleton.kt
+++ b/src/main/kotlin/org/patternfly/Skeleton.kt
@@ -1,0 +1,88 @@
+package org.patternfly
+
+import dev.fritz2.dom.html.Div
+import dev.fritz2.dom.html.RenderContext
+import kotlinx.coroutines.Job
+import org.w3c.dom.HTMLDivElement
+import org.w3c.dom.Node
+
+// ------------------------------------------------------ dsl
+
+/**
+ * Creates a [Skeleton] component.
+ *
+ * @param id optional id of the element
+ * @param baseClass optional CSS class(es) that should be applied to the element
+ * @param fontSize optional fontSize of the component
+ * @param height optional height of the component
+ * @param width optional width of the component
+ * @param shape optional shape of the component
+ * @param content a lambda expression for setting up the component itself
+ */
+public fun RenderContext.skeleton(
+    id: String? = null,
+    baseClass: String? = null,
+    fontSize: FontSize? = null,
+    height: Height? = null,
+    width: Width? = null,
+    shape: Shape? = null,
+    content: Skeleton.() -> Unit = {},
+): Skeleton = register(
+    Skeleton(
+        id = id,
+        baseClass = baseClass,
+        fontSize = fontSize,
+        height = height,
+        width = width,
+        shape = shape,
+        job
+    ),
+    content
+)
+
+// ------------------------------------------------------ tag
+
+/**
+ * PatternFly [skeleton](https://www.patternfly.org/v4/components/skeleton) component.
+ *
+ * A skeleton is a type of loading state that allows you to expose content incrementally. For content that may take a
+ * long time to load, use a [progress bar](https://www.patternfly.org/v4/components/progress) in place of a skeleton.
+ *
+ * @sample org.patternfly.sample.SkeletonSample.skeletons
+ */
+public class Skeleton internal constructor(
+    id: String?,
+    baseClass: String?,
+    fontSize: FontSize?,
+    height: Height?,
+    width: Width?,
+    shape: Shape?,
+    job: Job
+) : PatternFlyComponent<HTMLDivElement>,
+    Div(
+        id = id,
+        baseClass = classes {
+            +ComponentType.Skeleton
+            +baseClass
+            +fontSize?.modifier
+            +height?.modifier
+            +width?.modifier
+            +shape?.modifier
+        },
+        job
+    ) {
+
+    /**
+     * Override the default text content by creating an accessible SPAN which contains the given text.
+     */
+    override fun String.unaryPlus(): Node {
+        val screenReaderElement = span(baseClass = screenReader()) {
+            +this@unaryPlus
+        }
+        return domNode.appendChild(screenReaderElement.domNode)
+    }
+
+    init {
+        markAs(ComponentType.Skeleton)
+    }
+}

--- a/src/main/kotlin/org/patternfly/Skeleton.kt
+++ b/src/main/kotlin/org/patternfly/Skeleton.kt
@@ -4,7 +4,7 @@ import dev.fritz2.dom.html.Div
 import dev.fritz2.dom.html.RenderContext
 import kotlinx.coroutines.Job
 import org.w3c.dom.HTMLDivElement
-import org.w3c.dom.Node
+import org.w3c.dom.HTMLSpanElement
 
 // ------------------------------------------------------ dsl
 
@@ -59,6 +59,7 @@ public class Skeleton internal constructor(
     shape: Shape?,
     job: Job
 ) : PatternFlyComponent<HTMLDivElement>,
+    WithTextDelegate<HTMLDivElement, HTMLSpanElement>,
     Div(
         id = id,
         baseClass = classes {
@@ -72,14 +73,8 @@ public class Skeleton internal constructor(
         job
     ) {
 
-    /**
-     * Override the default text content by creating an accessible SPAN which contains the given text.
-     */
-    override fun String.unaryPlus(): Node {
-        val screenReaderElement = span(baseClass = screenReader()) {
-            +this@unaryPlus
-        }
-        return domNode.appendChild(screenReaderElement.domNode)
+    override fun delegate(): HTMLSpanElement {
+        return span(baseClass = screenReader()) {}.domNode
     }
 
     init {

--- a/src/main/kotlin/org/patternfly/Types.kt
+++ b/src/main/kotlin/org/patternfly/Types.kt
@@ -267,44 +267,44 @@ public enum class TriState(internal val checked: Boolean, internal val indetermi
  */
 @Suppress("EnumEntryName", "EnumNaming")
 public enum class Width(public val modifier: String) {
-    SM("sm".width()),
-    MD("md".width()),
-    LG("lg".width()),
-    _25("25".width()),
-    _33("33".width()),
-    _50("50".width()),
-    _66("66".width()),
-    _75("75".width()),
+    SM("width-sm".modifier()),
+    MD("width-md".modifier()),
+    LG("width-lg".modifier()),
+    _25("width-25".modifier()),
+    _33("width-33".modifier()),
+    _50("width-50".modifier()),
+    _66("width-66".modifier()),
+    _75("width-75".modifier()),
 }
 
 /**
- * Width modifier for [Skeleton] components.
+ * Height modifier for [Skeleton] components.
  */
 @Suppress("EnumEntryName", "EnumNaming")
 public enum class Height(public val modifier: String) {
-    SM("sm".width()),
-    MD("md".width()),
-    LG("lg".width()),
-    _25("25".height()),
-    _33("33".height()),
-    _50("50".height()),
-    _66("66".height()),
-    _75("75".height()),
-    _100("100".height()),
+    SM("height-sm".modifier()),
+    MD("height-md".modifier()),
+    LG("height-lg".modifier()),
+    _25("height-25".modifier()),
+    _33("height-33".modifier()),
+    _50("height-50".modifier()),
+    _66("height-66".modifier()),
+    _75("height-75".modifier()),
+    _100("height-100".modifier()),
 }
 
 /**
  * FontSize modifier for [Skeleton] components.
  */
 public enum class FontSize(public val modifier: String) {
-    XL_4("4xl".text()),
-    XL_3("3xl".text()),
-    XL_2("2xl".text()),
-    XL("xl".text()),
-    LG("lg".text()),
-    MD("md".text()),
-    SM("sm".text()),
-    XS("xs".text())
+    XL_4("text-4xl".modifier()),
+    XL_3("text-3xl".modifier()),
+    XL_2("text-2xl".modifier()),
+    XL("text-xl".modifier()),
+    LG("text-lg".modifier()),
+    MD("text-md".modifier()),
+    SM("text-sm".modifier()),
+    XS("text-xs".modifier())
 }
 
 /**

--- a/src/main/kotlin/org/patternfly/Types.kt
+++ b/src/main/kotlin/org/patternfly/Types.kt
@@ -66,7 +66,16 @@ public interface WithIdProvider<T> {
     public fun itemId(item: T): String = idProvider(item)
 }
 
-// Delegates the text related methods to another element
+/**
+ * Interface meant to be implemented by components which want to overwrite the default [String.unaryPlus] implementation.
+ *
+ * Note about the current implementation:
+ *  It delegates the text to the provided element.
+ *  Be aware that the text will be appended directly to the root of the provided Element.
+ *
+ * @param E component root Element
+ * @param D delegated root Element
+ */
 internal interface WithTextDelegate<E : HTMLElement, D : HTMLElement> : WithText<E> {
 
     override fun Flow<String>.asText() {
@@ -79,6 +88,9 @@ internal interface WithTextDelegate<E : HTMLElement, D : HTMLElement> : WithText
 
     override operator fun String.unaryPlus(): Node = delegate().appendChild(document.createTextNode(this))
 
+    /**
+     * Provide the desired Element
+     */
     fun delegate(): D
 }
 

--- a/src/main/kotlin/org/patternfly/Types.kt
+++ b/src/main/kotlin/org/patternfly/Types.kt
@@ -118,6 +118,7 @@ internal enum class ComponentType(val id: String, internal val baseClass: String
     PageSidebar("pgs", "page".component("sidebar")),
     Pagination("pgn", "pagination".component()),
     Select("sel", "select".component()),
+    Skeleton("sk", "skeleton".component()),
     Spinner("sp", "spinner".component()),
     Switch("sw", "switch".component()),
     Tabs("tbs"),
@@ -259,4 +260,57 @@ public enum class TriState(internal val checked: Boolean, internal val indetermi
     OFF(false, false),
     INDETERMINATE(false, true),
     ON(true, false)
+}
+
+/**
+ * Width modifier for [Skeleton] components.
+ */
+@Suppress("EnumEntryName", "EnumNaming")
+public enum class Width(public val modifier: String) {
+    SM("sm".width()),
+    MD("md".width()),
+    LG("lg".width()),
+    _25("25".width()),
+    _33("33".width()),
+    _50("50".width()),
+    _66("66".width()),
+    _75("75".width()),
+}
+
+/**
+ * Width modifier for [Skeleton] components.
+ */
+@Suppress("EnumEntryName", "EnumNaming")
+public enum class Height(public val modifier: String) {
+    SM("sm".width()),
+    MD("md".width()),
+    LG("lg".width()),
+    _25("25".height()),
+    _33("33".height()),
+    _50("50".height()),
+    _66("66".height()),
+    _75("75".height()),
+    _100("100".height()),
+}
+
+/**
+ * FontSize modifier for [Skeleton] components.
+ */
+public enum class FontSize(public val modifier: String) {
+    XL_4("4xl".text()),
+    XL_3("3xl".text()),
+    XL_2("2xl".text()),
+    XL("xl".text()),
+    LG("lg".text()),
+    MD("md".text()),
+    SM("sm".text()),
+    XS("xs".text())
+}
+
+/**
+ * Shape modifier for [Skeleton] components.
+ */
+public enum class Shape(public val modifier: String) {
+    CIRCLE("circle".modifier()),
+    SQUARE("square".modifier()),
 }

--- a/src/main/resources/org/patternfly/sample/SkeletonSample.kt
+++ b/src/main/resources/org/patternfly/sample/SkeletonSample.kt
@@ -1,0 +1,20 @@
+package org.patternfly.sample
+
+import dev.fritz2.dom.html.render
+import org.patternfly.FontSize
+import org.patternfly.Height
+import org.patternfly.Shape
+import org.patternfly.Width
+import org.patternfly.skeleton
+
+internal interface SkeletonSample {
+    fun skeletons() {
+        render {
+            skeleton()
+            skeleton(id = "skeleton-with-custom-font-size", fontSize = FontSize.XL_4)
+            skeleton(id = "skeleton-with-custom-width-and-height", width = Width._33, height = Height._66)
+            skeleton(id = "skeleton-as-a-circle", shape = Shape.CIRCLE, width = Width.SM)
+            skeleton(id = "skeleton-with-accessible-text") { +"Content loading..." }
+        }
+    }
+}

--- a/src/test/kotlin/org/patternfly/DomTestSetupHelper.kt
+++ b/src/test/kotlin/org/patternfly/DomTestSetupHelper.kt
@@ -1,0 +1,25 @@
+package org.patternfly
+
+import kotlinx.browser.document
+
+/**
+ * Create an empty DIV Element in the document root (body).
+ * The created element can then be used for component mounting.
+ *
+ * @param id of the created element
+ */
+fun createRootElement(id: String = "target") {
+    val div = document.createElement("div")
+    div.id = id
+    document.body!!.appendChild(div)
+}
+
+/**
+ * Remove an element from the dom by id
+ * It ignores unknown id's
+ *
+ * @param id of the element
+ */
+fun removeElementById(id: String = "target") {
+    document.getElementById(id)?.remove()
+}

--- a/src/test/kotlin/org/patternfly/SkeletonTests.kt
+++ b/src/test/kotlin/org/patternfly/SkeletonTests.kt
@@ -1,0 +1,55 @@
+package org.patternfly
+
+import dev.fritz2.dom.html.render
+import dev.fritz2.dom.mount
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+import kotlinx.browser.document
+import org.w3c.dom.asList
+
+@Suppress("unused")
+class SkeletonTests : StringSpec() {
+    private val target = "target"
+
+    override fun beforeEach(testCase: TestCase) {
+        super.beforeEach(testCase)
+
+        removeElementById(target)
+        createRootElement(target)
+    }
+
+    init {
+        "should be created" {
+            render {
+                skeleton(id = "skeleton", baseClass = "additional-class es")
+            }.mount(target)
+
+            val element = document.getElementById("skeleton")!!
+            element.nodeName shouldBe "DIV"
+            element.classList.asList() shouldBe listOf("pf-c-skeleton", "additional-class", "es")
+            element.childElementCount shouldBe 0
+        }
+
+        "should be modifiable in shape and size" {
+            render {
+                skeleton(id = "small-circle", shape = Shape.CIRCLE, width = Width.SM)
+            }.mount(target)
+
+            val element = document.getElementById("small-circle")!!
+            element.classList.asList() shouldBe listOf("pf-c-skeleton", "pf-m-width-sm", "pf-m-circle")
+        }
+
+        "should be accessible" {
+            render {
+                skeleton(id = "accessible-skeleton") { +"Content loading..." }
+            }.mount(target)
+
+            val element = document.getElementById("accessible-skeleton")!!
+            element.childElementCount shouldBe 1
+            element.firstElementChild!!.nodeName shouldBe "SPAN"
+            element.firstElementChild!!.classList.asList() shouldBe listOf("pf-u-screen-reader")
+            element.firstElementChild!!.textContent shouldBe "Content loading..."
+        }
+    }
+}


### PR DESCRIPTION
Hi, after your KotlinJs presentation, I got a little curious and tried to implement the skeleton component (#48).

Some points for discussion:
- Naming of EnumEntries: I have defined numbers prefixed with underscore (eg. `_33`). Maybe there's a better solution? See Types.kt:273
- Testing was a bit tricky.  In order to test the component I created a root-Element, which serves as a 'mounting' point.
- Would it be preferable to pass the screenReaderText as a parameter instead of overloading the unaryPlus? Skeleton.kt:78

@mentions of the person or team responsible for reviewing proposed changes @hpehl 
Looking forward to your feedback

